### PR TITLE
dockerisation du serveur (Dockerfile + Compose) + correction mineur TronClientFX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM maven:3.9.6-eclipse-temurin-21-alpine AS build
+
+WORKDIR /app
+
+# Copie des fichiers de configuration
+COPY pom.xml .
+
+# Téléchargement des dépendances
+RUN mvn dependency:go-offline
+
+# Copie du code source
+COPY src ./src
+
+# Compilation (crée le fichier Light_Tron_Cycle_2D-1.0-SNAPSHOT.jar dans /app/target)
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+# On le renomme "server.jar" uniquement DANS le conteneur pour simplifier la commande suivante
+COPY --from=build /app/target/Light_Tron_Cycle_2D-1.0-SNAPSHOT.jar server.jar
+
+# On expose le port
+EXPOSE 2222
+
+# On lance le serveur
+ENTRYPOINT ["java", "-jar", "server.jar", "server"]
+
+CMD ["-p", "2222"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  tron-server:
+    build: .
+    container_name: light-tron-server
+    ports:
+      - "2222:2222"
+    restart: unless-stopped
+    environment:
+      - TZ=Europe/Zurich

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
     </properties>
 
     <dependencies>
-        <!-- Picocli pour la gestion des arguments -->
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
@@ -43,7 +42,6 @@
 
     <build>
         <plugins>
-            <!-- 1. Plugin Compiler : Indique d'utiliser Java 21 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -54,18 +52,15 @@
                 </configuration>
             </plugin>
 
-            <!-- 2. Plugin JavaFX : Pour lancer via 'mvn javafx:run' pendant le dev -->
             <plugin>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.8</version>
                 <configuration>
-                    <!-- On pointe sur Launcher ou Main pour tester -->
                     <mainClass>ch.heigvd.Main</mainClass>
                 </configuration>
             </plugin>
 
-            <!-- 3. Plugin Shade : CRITIQUE pour créer un JAR exécutable avec dépendances -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -79,11 +74,9 @@
                         <configuration>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <!-- C'est ici qu'on définit le point d'entrée principal -->
                                     <mainClass>ch.heigvd.Main</mainClass>
                                 </transformer>
                             </transformers>
-                            <!-- Filtre pour éviter les erreurs de signature JAR -->
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>

--- a/src/main/java/ch/heigvd/gui/TronClientFX.java
+++ b/src/main/java/ch/heigvd/gui/TronClientFX.java
@@ -41,7 +41,6 @@ public class TronClientFX extends Application {
         gameCanvas.widthProperty().bind(canvasContainer.widthProperty());
         gameCanvas.heightProperty().bind(canvasContainer.heightProperty());
 
-        // Redessiner au redimensionnement
         gameCanvas.widthProperty().addListener(obs -> gameCanvas.draw());
         gameCanvas.heightProperty().addListener(obs -> gameCanvas.draw());
 
@@ -98,23 +97,19 @@ public class TronClientFX extends Application {
                     state.p1x = p1x; state.p1y = p1y; state.p1Alive = p1Alive;
                     state.p2x = p2x; state.p2y = p2y; state.p2Alive = p2Alive;
 
-                    // Mise à jour des traces P1
+                    // --- CORRECTION MAJEURE ICI ---
+                    // On remplace la liste locale par celle du serveur (état autoritaire)
+
+                    state.p1Trails.clear();
                     if (!t1.isEmpty()) {
                         state.p1Trails.addAll(t1);
-                    } else if (phase.equals("RUNNING") && state.p1Trails.isEmpty()) {
-                        // Reset debut de partie (si liste serveur vide, liste locale vide)
                     }
 
-                    // Mise à jour des traces P2
+                    state.p2Trails.clear();
                     if (!t2.isEmpty()) {
                         state.p2Trails.addAll(t2);
                     }
-
-                    // Reset complet si retour au lobby
-                    if (phase.equals("LOBBY") && (!state.p1Trails.isEmpty() || !state.p2Trails.isEmpty())) {
-                        state.p1Trails.clear();
-                        state.p2Trails.clear();
-                    }
+                    // ------------------------------
 
                     statusLabel.setText("Phase: " + phase);
                     gameCanvas.draw();
@@ -134,9 +129,7 @@ public class TronClientFX extends Application {
                     alert.show();
 
                     startButton.setDisable(false);
-                    // On vide les listes pour la prochaine
-                    state.p1Trails.clear();
-                    state.p2Trails.clear();
+                    // Pas besoin de vider ici, le prochain STATE LOBBY ou RUNNING le fera via les clear() ci-dessus
                 });
             }
 


### PR DESCRIPTION
Changements techniques

TronClientFX : 

- Correction des traces laissées par les motos : on réécrivait cela à chaque fois mais plus maintenant, cela est plus léger et rapide

Dockerfile : Utilisation d'un build en 2 étapes:

- Etape1 (Build) : Image maven:3-alpine pour compiler le projet et générer le Fat JAR.

- Etape2 (Run) : Image eclipse-temurin:21-jre-alpine pour exécuter uniquement le serveur.

docker-compose.yml : 

- Orchestration simple pour lancer le conteneur et mapper le port 2222 de l'hôte vers le conteneur.